### PR TITLE
feat: support the dark theme for ACGHelper (formerly Bilibili Helper).

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -19,7 +19,7 @@ export const getIsInternalTesting = once(() => {
  * document.querySelector('[data-name=darkMode] .main-content').click()
  */
 
-const getIsDarkMode = () => document.body.classList.contains('dark')
+const getIsDarkMode = () => document.body.classList.contains('dark') || document.body.classList.contains('bilibili-helper-dark-mode')
 // ||
 // document.documentElement.getAttribute('data-darkreader-scheme') === 'dark'
 const isDarkModeState = proxy({ value: getIsDarkMode() }) // like vue3 ref()


### PR DESCRIPTION
适配acghelper(原bilibili-helper)的暗黑模式

另外我本地运行的时候，vite解析不了$的路径别名，只有将main.tsx里的所有$别名改成相对路径./才能正常打包运行。
作者有什么头绪吗

```
build:vite: [vite]: Rollup failed to resolve import "$common" from "D:\Workspace\CodeSpace\bilibili-app-recommend\src\main.tsx".
build:vite: This is most likely unintended because it can break your application at runtime.
build:vite: If you do want to externalize this module explicitly add it to
build:vite: `build.rollupOptions.external`
```